### PR TITLE
Display 4 locations on homepage and expand on click

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -463,6 +463,10 @@ footer {
     gap: 1.5rem;
 }
 
+.location-item.hidden {
+    display: none;
+}
+
 .location-item a {
     display: block;
     background-color: var(--light-gray);

--- a/index.html
+++ b/index.html
@@ -187,14 +187,29 @@
                             <h3>Hackney</h3>
                         </a>
                     </div>
-                    <div class="location-item">
+                    <div class="location-item hidden">
                         <a href="locations/kensington.html">
                             <h3>Kensington</h3>
                         </a>
                     </div>
+                    <div class="location-item hidden">
+                        <a href="locations/luton.html">
+                            <h3>Luton</h3>
+                        </a>
+                    </div>
+                    <div class="location-item hidden">
+                        <a href="locations/croydon.html">
+                            <h3>Croydon</h3>
+                        </a>
+                    </div>
+                    <div class="location-item hidden">
+                        <a href="locations/harrow.html">
+                            <h3>Harrow</h3>
+                        </a>
+                    </div>
                 </div>
                 <div style="text-align: center; margin-top: 2rem;">
-                    <a href="locations.html" class="cta-button">View All Locations</a>
+                    <a href="#" id="view-all-locations" class="cta-button">View All Locations</a>
                 </div>
             </div>
         </section>

--- a/js/script.js
+++ b/js/script.js
@@ -50,4 +50,14 @@ document.addEventListener('DOMContentLoaded', function() {
         setInterval(nextSlide, 5000); // Autoplay every 5 seconds
         window.addEventListener('resize', showSlides);
     }
+
+    // Reveal all locations on index page
+    const viewAllBtn = document.querySelector('#view-all-locations');
+    if (viewAllBtn) {
+        viewAllBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            document.querySelectorAll('.location-item.hidden').forEach(item => item.classList.remove('hidden'));
+            viewAllBtn.style.display = 'none';
+        });
+    }
 });

--- a/locations.html
+++ b/locations.html
@@ -121,6 +121,21 @@
                             <h3>Locksmith in Kensington</h3>
                         </a>
                     </div>
+                    <div class="location-item">
+                        <a href="locations/luton.html">
+                            <h3>Locksmith in Luton</h3>
+                        </a>
+                    </div>
+                    <div class="location-item">
+                        <a href="locations/croydon.html">
+                            <h3>Locksmith in Croydon</h3>
+                        </a>
+                    </div>
+                    <div class="location-item">
+                        <a href="locations/harrow.html">
+                            <h3>Locksmith in Harrow</h3>
+                        </a>
+                    </div>
                 </div>
             </div>
         </section>

--- a/locations/croydon.html
+++ b/locations/croydon.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Locksmith in Croydon - 24/7 Service</title>
+    <meta name="description" content="Need a locksmith in Croydon? We offer fast, reliable 24/7 locksmith services throughout the Croydon area. Call for a 15-30 minute response.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Locksmith",
+      "name": "Locksmith in Croydon",
+      "image": "https://www.example.com/logo.jpg",
+      "@id": "",
+      "url": "https://www.example.com/locations/croydon.html",
+      "telephone": "0123-456-7890",
+      "priceRange": "$$",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "123 Locking St",
+        "addressLocality": "London",
+        "postalCode": "E1 6AN",
+        "addressCountry": "UK"
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "Croydon"
+       },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 51.3726,
+        "longitude": -0.1090
+      },
+      "openingHoursSpecification": {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday"
+        ],
+        "opens": "00:00",
+        "closes": "23:59"
+      },
+      "sameAs": [
+        "https://www.facebook.com/your-locksmith",
+        "https://www.twitter.com/your-locksmith"
+      ]
+    }
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <a href="../index.html">
+                    <img src="../images/website-logo.png" alt="Locksmith Logo">
+                </a>
+            </div>
+            <nav>
+                <ul>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../services.html">Services</a></li>
+                    <li><a href="../locations.html">Locations</a></li>
+                    <li><a href="../contact.html">Contact Us</a></li>
+                </ul>
+            </nav>
+            <div class="header-phone">
+                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+            </div>
+            <button class="mobile-nav-toggle">&#9776;</button>
+        </div>
+    </header>
+
+    <nav class="mobile-nav">
+        <ul>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../services.html">Services</a></li>
+            <li><a href="../locations.html">Locations</a></li>
+            <li><a href="../contact.html">Contact Us</a></li>
+        </ul>
+    </nav>
+
+    <main class="service-page">
+        <section class="hero-small">
+            <div class="container">
+                <h1>Locksmith in Croydon</h1>
+            </div>
+        </section>
+
+        <section class="service-content">
+            <div class="container">
+                <div class="service-description">
+                    <h2>Your Trusted Locksmith in Croydon</h2>
+                    <p>If you're in Croydon and need a fast, professional locksmith, you've come to the right place. We are proud to serve the entire Croydon area, providing a full range of locksmith services to residents and businesses. Our local technicians can be with you in just 15-30 minutes.</p>
+                    <p>We know the Croydon area well and can navigate the streets quickly to get to you when you need us most. Our services in Croydon include:</p>
+                    <ul>
+                        <li>24/7 Emergency Lockouts</li>
+                        <li>Lock Changes and Repairs</li>
+                        <li>Home and Business Security Upgrades</li>
+                        <li>UPVC Door and Window Lock Services</li>
+                        <li>And much more...</li>
+                    </ul>
+                </div>
+                <div class="service-cta">
+                    <h3>Need a Locksmith in Croydon?</h3>
+                    <p>We're just a phone call away. Contact us for immediate service.</p>
+                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-flex">
+                <div class="footer-about">
+                    <h3>Locksmith</h3>
+                    <p>Your local, reliable locksmith service. Available 24/7 for all your locksmith needs.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Links</h3>
+                    <ul>
+                        <li><a href="../index.html">Home</a></li>
+                        <li><a href="../services.html">Services</a></li>
+                        <li><a href="../locations.html">Locations</a></li>
+                        <li><a href="../contact.html">Contact Us</a></li>
+                        <li><a href="../privacy-policy.html">Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="footer-contact">
+                    <h3>Contact Us</h3>
+                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
+                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <div class="social-media">
+                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#"><i class="fab fa-twitter"></i></a>
+                        <a href="#"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 Locksmith. All Rights Reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>

--- a/locations/harrow.html
+++ b/locations/harrow.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Locksmith in Harrow - 24/7 Service</title>
+    <meta name="description" content="Need a locksmith in Harrow? We offer fast, reliable 24/7 locksmith services throughout the Harrow area. Call for a 15-30 minute response.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Locksmith",
+      "name": "Locksmith in Harrow",
+      "image": "https://www.example.com/logo.jpg",
+      "@id": "",
+      "url": "https://www.example.com/locations/harrow.html",
+      "telephone": "0123-456-7890",
+      "priceRange": "$$",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "123 Locking St",
+        "addressLocality": "London",
+        "postalCode": "E1 6AN",
+        "addressCountry": "UK"
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "Harrow"
+       },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 51.5806,
+        "longitude": -0.3429
+      },
+      "openingHoursSpecification": {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday"
+        ],
+        "opens": "00:00",
+        "closes": "23:59"
+      },
+      "sameAs": [
+        "https://www.facebook.com/your-locksmith",
+        "https://www.twitter.com/your-locksmith"
+      ]
+    }
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <a href="../index.html">
+                    <img src="../images/website-logo.png" alt="Locksmith Logo">
+                </a>
+            </div>
+            <nav>
+                <ul>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../services.html">Services</a></li>
+                    <li><a href="../locations.html">Locations</a></li>
+                    <li><a href="../contact.html">Contact Us</a></li>
+                </ul>
+            </nav>
+            <div class="header-phone">
+                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+            </div>
+            <button class="mobile-nav-toggle">&#9776;</button>
+        </div>
+    </header>
+
+    <nav class="mobile-nav">
+        <ul>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../services.html">Services</a></li>
+            <li><a href="../locations.html">Locations</a></li>
+            <li><a href="../contact.html">Contact Us</a></li>
+        </ul>
+    </nav>
+
+    <main class="service-page">
+        <section class="hero-small">
+            <div class="container">
+                <h1>Locksmith in Harrow</h1>
+            </div>
+        </section>
+
+        <section class="service-content">
+            <div class="container">
+                <div class="service-description">
+                    <h2>Your Trusted Locksmith in Harrow</h2>
+                    <p>If you're in Harrow and need a fast, professional locksmith, you've come to the right place. We are proud to serve the entire Harrow area, providing a full range of locksmith services to residents and businesses. Our local technicians can be with you in just 15-30 minutes.</p>
+                    <p>We know the Harrow area well and can navigate the streets quickly to get to you when you need us most. Our services in Harrow include:</p>
+                    <ul>
+                        <li>24/7 Emergency Lockouts</li>
+                        <li>Lock Changes and Repairs</li>
+                        <li>Home and Business Security Upgrades</li>
+                        <li>UPVC Door and Window Lock Services</li>
+                        <li>And much more...</li>
+                    </ul>
+                </div>
+                <div class="service-cta">
+                    <h3>Need a Locksmith in Harrow?</h3>
+                    <p>We're just a phone call away. Contact us for immediate service.</p>
+                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-flex">
+                <div class="footer-about">
+                    <h3>Locksmith</h3>
+                    <p>Your local, reliable locksmith service. Available 24/7 for all your locksmith needs.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Links</h3>
+                    <ul>
+                        <li><a href="../index.html">Home</a></li>
+                        <li><a href="../services.html">Services</a></li>
+                        <li><a href="../locations.html">Locations</a></li>
+                        <li><a href="../contact.html">Contact Us</a></li>
+                        <li><a href="../privacy-policy.html">Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="footer-contact">
+                    <h3>Contact Us</h3>
+                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
+                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <div class="social-media">
+                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#"><i class="fab fa-twitter"></i></a>
+                        <a href="#"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 Locksmith. All Rights Reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>

--- a/locations/luton.html
+++ b/locations/luton.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Locksmith in Luton - 24/7 Service</title>
+    <meta name="description" content="Need a locksmith in Luton? We offer fast, reliable 24/7 locksmith services throughout the Luton area. Call for a 15-30 minute response.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Locksmith",
+      "name": "Locksmith in Luton",
+      "image": "https://www.example.com/logo.jpg",
+      "@id": "",
+      "url": "https://www.example.com/locations/luton.html",
+      "telephone": "0123-456-7890",
+      "priceRange": "$$",
+      "address": {
+        "@type": "PostalAddress",
+        "streetAddress": "123 Locking St",
+        "addressLocality": "London",
+        "postalCode": "E1 6AN",
+        "addressCountry": "UK"
+      },
+      "areaServed": {
+        "@type": "Place",
+        "name": "Luton"
+       },
+      "geo": {
+        "@type": "GeoCoordinates",
+        "latitude": 51.8797,
+        "longitude": -0.4175
+      },
+      "openingHoursSpecification": {
+        "@type": "OpeningHoursSpecification",
+        "dayOfWeek": [
+          "Monday",
+          "Tuesday",
+          "Wednesday",
+          "Thursday",
+          "Friday",
+          "Saturday",
+          "Sunday"
+        ],
+        "opens": "00:00",
+        "closes": "23:59"
+      },
+      "sameAs": [
+        "https://www.facebook.com/your-locksmith",
+        "https://www.twitter.com/your-locksmith"
+      ]
+    }
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <a href="../index.html">
+                    <img src="../images/website-logo.png" alt="Locksmith Logo">
+                </a>
+            </div>
+            <nav>
+                <ul>
+                    <li><a href="../index.html">Home</a></li>
+                    <li><a href="../services.html">Services</a></li>
+                    <li><a href="../locations.html">Locations</a></li>
+                    <li><a href="../contact.html">Contact Us</a></li>
+                </ul>
+            </nav>
+            <div class="header-phone">
+                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+            </div>
+            <button class="mobile-nav-toggle">&#9776;</button>
+        </div>
+    </header>
+
+    <nav class="mobile-nav">
+        <ul>
+            <li><a href="../index.html">Home</a></li>
+            <li><a href="../services.html">Services</a></li>
+            <li><a href="../locations.html">Locations</a></li>
+            <li><a href="../contact.html">Contact Us</a></li>
+        </ul>
+    </nav>
+
+    <main class="service-page">
+        <section class="hero-small">
+            <div class="container">
+                <h1>Locksmith in Luton</h1>
+            </div>
+        </section>
+
+        <section class="service-content">
+            <div class="container">
+                <div class="service-description">
+                    <h2>Your Trusted Locksmith in Luton</h2>
+                    <p>If you're in Luton and need a fast, professional locksmith, you've come to the right place. We are proud to serve the entire Luton area, providing a full range of locksmith services to residents and businesses. Our local technicians can be with you in just 15-30 minutes.</p>
+                    <p>We know the Luton area well and can navigate the streets quickly to get to you when you need us most. Our services in Luton include:</p>
+                    <ul>
+                        <li>24/7 Emergency Lockouts</li>
+                        <li>Lock Changes and Repairs</li>
+                        <li>Home and Business Security Upgrades</li>
+                        <li>UPVC Door and Window Lock Services</li>
+                        <li>And much more...</li>
+                    </ul>
+                </div>
+                <div class="service-cta">
+                    <h3>Need a Locksmith in Luton?</h3>
+                    <p>We're just a phone call away. Contact us for immediate service.</p>
+                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-flex">
+                <div class="footer-about">
+                    <h3>Locksmith</h3>
+                    <p>Your local, reliable locksmith service. Available 24/7 for all your locksmith needs.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Links</h3>
+                    <ul>
+                        <li><a href="../index.html">Home</a></li>
+                        <li><a href="../services.html">Services</a></li>
+                        <li><a href="../locations.html">Locations</a></li>
+                        <li><a href="../contact.html">Contact Us</a></li>
+                        <li><a href="../privacy-policy.html">Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="footer-contact">
+                    <h3>Contact Us</h3>
+                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
+                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <div class="social-media">
+                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a href="#"><i class="fab fa-twitter"></i></a>
+                        <a href="#"><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 Locksmith. All Rights Reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="../js/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Show only the first four service areas on the homepage and reveal the rest with a "View All Locations" button.
- Add Luton, Croydon, and Harrow to the service area list with dedicated pages for each.
- Include styling and scripting to hide extra locations until requested.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c29b5d5d48832ba6fe5ada3bfb4c32