### PR TITLE
Add location icons on homepage and reduce page icon size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -218,10 +218,11 @@ header nav {
 }
 
 .content-image {
-    width: 100%;
+    width: 80px;
     height: auto;
     border-radius: 5px;
-    margin-bottom: 1rem;
+    display: block;
+    margin: 0 auto 1rem;
 }
 
 .locations-overview {

--- a/index.html
+++ b/index.html
@@ -203,41 +203,49 @@
                 <div class="location-grid">
                     <div class="location-item">
                         <a href="locations/islington.html">
+                            <img src="images/islington.svg" alt="Islington" class="content-image">
                             <h3>Islington</h3>
                         </a>
                     </div>
                     <div class="location-item">
                         <a href="locations/camden.html">
+                            <img src="images/camden.svg" alt="Camden" class="content-image">
                             <h3>Camden</h3>
                         </a>
                     </div>
                     <div class="location-item">
                         <a href="locations/westminster.html">
+                            <img src="images/westminster.svg" alt="Westminster" class="content-image">
                             <h3>Westminster</h3>
                         </a>
                     </div>
                     <div class="location-item">
                         <a href="locations/hackney.html">
+                            <img src="images/hackney.svg" alt="Hackney" class="content-image">
                             <h3>Hackney</h3>
                         </a>
                     </div>
                     <div class="location-item hidden">
                         <a href="locations/kensington.html">
+                            <img src="images/kensington.svg" alt="Kensington" class="content-image">
                             <h3>Kensington</h3>
                         </a>
                     </div>
                     <div class="location-item hidden">
                         <a href="locations/luton.html">
+                            <img src="images/luton.svg" alt="Luton" class="content-image">
                             <h3>Luton</h3>
                         </a>
                     </div>
                     <div class="location-item hidden">
                         <a href="locations/croydon.html">
+                            <img src="images/croydon.svg" alt="Croydon" class="content-image">
                             <h3>Croydon</h3>
                         </a>
                     </div>
                     <div class="location-item hidden">
                         <a href="locations/harrow.html">
+                            <img src="images/harrow.svg" alt="Harrow" class="content-image">
                             <h3>Harrow</h3>
                         </a>
                     </div>


### PR DESCRIPTION
## Summary
- show location-specific icons on the home page
- shrink content icons across service and location pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a6d6fe5c832bb259597d11114bad