### PR TITLE
Add animated stats and area coverage sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -521,6 +521,141 @@ footer {
     color: var(--accent-color);
 }
 
+/* Stats Section */
+.stats {
+    padding: 2rem 0;
+    background-color: var(--secondary-color);
+}
+.stats .container {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1.5rem;
+    text-align: center;
+}
+.stats .stat {
+    padding: 1rem 0;
+}
+.stat i {
+    font-size: 2rem;
+    color: var(--accent-color);
+    margin-bottom: 0.5rem;
+}
+.stat-number {
+    font-size: 2rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+.stat-label {
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+@media (min-width: 768px) {
+    .stats .stat:not(:last-child) {
+        border-right: 1px dotted var(--light-gray);
+    }
+}
+
+/* Feature Highlights */
+.feature-highlights {
+    padding: 2rem 0;
+    border-top: 1px solid var(--light-gray);
+    border-bottom: 1px solid var(--light-gray);
+}
+.feature-highlights .container {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+    gap: 2rem;
+}
+.feature i {
+    font-size: 1.8rem;
+    color: #e53935;
+    margin-bottom: 0.5rem;
+}
+@media (min-width: 768px) {
+    .feature-highlights .container {
+        flex-direction: row;
+        justify-content: space-between;
+    }
+}
+
+/* Area Coverage */
+.area-coverage {
+    padding: 3rem 0;
+    background-color: var(--light-gray);
+}
+.area-coverage h2,
+.area-coverage p {
+    text-align: center;
+}
+.coverage-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin-top: 2rem;
+}
+.coverage-box {
+    background-color: var(--secondary-color);
+    padding: 1.5rem;
+    border-radius: 5px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.05);
+}
+.coverage-box h3 {
+    margin-top: 0;
+}
+.coverage-box ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.coverage-box li {
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+}
+.coverage-box li i {
+    color: var(--accent-color);
+    margin-right: 0.5rem;
+}
+.new-tag {
+    color: var(--accent-color);
+}
+
+/* Brand Logos */
+.brand-logos {
+    padding: 3rem 0;
+}
+.brand-logos h2 {
+    text-align: center;
+    margin-bottom: 2rem;
+}
+.brand-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+    gap: 1rem;
+    justify-items: center;
+    margin-bottom: 2rem;
+}
+.brand {
+    background-color: var(--light-gray);
+    padding: 1rem;
+    border-radius: 5px;
+    width: 100%;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+}
+.brand-check {
+    text-align: center;
+}
+.brand-check i {
+    font-size: 3rem;
+    color: var(--accent-color);
+}
+
 /* Mobile Navigation */
 .mobile-nav-toggle {
     display: block;

--- a/index.html
+++ b/index.html
@@ -99,6 +99,51 @@
             </div>
         </section>
 
+        <section class="stats fade-in-element">
+            <div class="container">
+                <div class="stat">
+                    <i class="fas fa-calendar-alt"></i>
+                    <div class="stat-number counter" data-target="20">0</div>
+                    <p class="stat-label">Years of Experience</p>
+                </div>
+                <div class="stat">
+                    <i class="fas fa-lock-open"></i>
+                    <div class="stat-number counter" data-target="38549">0</div>
+                    <p class="stat-label">Doors Unlocked</p>
+                </div>
+                <div class="stat">
+                    <i class="fas fa-user-cog"></i>
+                    <div class="stat-number counter" data-target="15">0</div>
+                    <p class="stat-label">Technicians</p>
+                </div>
+                <div class="stat">
+                    <i class="fas fa-clock"></i>
+                    <div class="stat-number counter" data-target="23">0</div>
+                    <p class="stat-label">Avg Attending Time (Min)</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="feature-highlights fade-in-element">
+            <div class="container">
+                <div class="feature">
+                    <i class="fas fa-bolt"></i>
+                    <h4>Fast Response</h4>
+                    <p>We arrive in 30 minutes</p>
+                </div>
+                <div class="feature">
+                    <i class="fas fa-thumbs-up"></i>
+                    <h4>Best Choice Guarantee</h4>
+                    <p>Professional Locksmiths</p>
+                </div>
+                <div class="feature">
+                    <i class="fas fa-map-marker-alt"></i>
+                    <h4>Biggest Coverage</h4>
+                    <p>We cover all of Greater London</p>
+                </div>
+            </div>
+        </section>
+
         <section class="trust-signals fade-in-element is-visible">
             <div class="container">
                 <div class="signal">
@@ -192,6 +237,62 @@
                             <h3>Smart Lock Installation</h3>
                         </a>
                     </div>
+                </div>
+            </div>
+        </section>
+        <section class="area-coverage fade-in-element">
+            <div class="container">
+                <h2>London Area Covered</h2>
+                <p>Our mobile locksmiths covering all locations from Greater London, ready to help you.</p>
+                <div class="coverage-grid">
+                    <div class="coverage-box">
+                        <ul>
+                            <li><i class="fas fa-check"></i>West London</li>
+                            <li><i class="fas fa-check"></i>North London</li>
+                            <li><i class="fas fa-check"></i>North West London</li>
+                            <li><i class="fas fa-check"></i>East London</li>
+                            <li><i class="fas fa-check"></i>South West London</li>
+                            <li><i class="fas fa-check"></i>South East London</li>
+                        </ul>
+                    </div>
+                    <div class="coverage-box">
+                        <h3><span class="new-tag">NEW!</span> We also cover ALL outskirts of London, such as:</h3>
+                        <ul>
+                            <li><i class="fas fa-check"></i>WD – Watford</li>
+                            <li><i class="fas fa-check"></i>EN – Enfield</li>
+                            <li><i class="fas fa-check"></i>HA – Harrow</li>
+                            <li><i class="fas fa-check"></i>UB – Uxbridge</li>
+                            <li><i class="fas fa-check"></i>IG – Ilford</li>
+                            <li><i class="fas fa-check"></i>RM – Romford</li>
+                            <li><i class="fas fa-check"></i>TW – Hounslow</li>
+                            <li><i class="fas fa-check"></i>DA – Dartford</li>
+                            <li><i class="fas fa-check"></i>KT – Kingston upon Thames</li>
+                            <li><i class="fas fa-check"></i>SM – Sutton</li>
+                            <li><i class="fas fa-check"></i>CR – Croydon</li>
+                            <li><i class="fas fa-check"></i>BR – Bromley</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="brand-logos fade-in-element">
+            <div class="container">
+                <h2>Full List of Locksmith Services we Offer</h2>
+                <div class="brand-grid">
+                    <div class="brand"><span>Yale</span></div>
+                    <div class="brand"><span>Chubb</span></div>
+                    <div class="brand"><span>EVVA</span></div>
+                    <div class="brand"><span>Union</span></div>
+                    <div class="brand"><span>Asec</span></div>
+                    <div class="brand"><span>Ingersoll</span></div>
+                    <div class="brand"><span>ERA</span></div>
+                    <div class="brand"><span>Multi Lock</span></div>
+                    <div class="brand"><span>Cisa</span></div>
+                </div>
+                <div class="brand-check">
+                    <i class="fas fa-circle-check"></i>
+                    <p>DBS Checked</p>
                 </div>
             </div>
         </section>

--- a/js/script.js
+++ b/js/script.js
@@ -60,4 +60,21 @@ document.addEventListener('DOMContentLoaded', function() {
             viewAllBtn.style.display = 'none';
         });
     }
+
+    // Animated counters
+    const counters = document.querySelectorAll('.counter');
+    counters.forEach(counter => {
+        const updateCount = () => {
+            const target = +counter.getAttribute('data-target');
+            const count = +counter.innerText.replace(/,/g, '');
+            const increment = target / 200;
+            if (count < target) {
+                counter.innerText = Math.ceil(count + increment).toLocaleString();
+                requestAnimationFrame(updateCount);
+            } else {
+                counter.innerText = target.toLocaleString();
+            }
+        };
+        updateCount();
+    });
 });


### PR DESCRIPTION
## Summary
- Introduce stats and feature highlight sections with Font Awesome icons and animated counters.
- Add detailed London area coverage and outskirts list with check icons plus brand logo grid.
- Style new sections and counters for responsive layout and fade-in animations.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2aae785e8832bb30e849091e4f478