### PR TITLE
Add floating phone bubble and WhatsApp chat button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -766,3 +766,64 @@ footer {
     opacity: 1;
     transform: translateY(0);
 }
+
+/* Floating contact elements */
+.phone-bubble {
+    position: fixed;
+    right: 20px;
+    bottom: 100px;
+    background-color: var(--accent-color);
+    color: var(--secondary-color);
+    padding: 0.75rem 1rem;
+    border-radius: 25px;
+    font-weight: 700;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    opacity: 0;
+    animation: slide-in 0.5s forwards, float 3s ease-in-out infinite 0.5s;
+    z-index: 1000;
+}
+
+.phone-bubble a {
+    color: var(--secondary-color);
+}
+
+.whatsapp-chat {
+    position: fixed;
+    right: 20px;
+    bottom: 20px;
+    background-color: #25d366;
+    color: #fff;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    z-index: 1000;
+}
+
+.whatsapp-chat:hover {
+    background-color: #1ebe5d;
+}
+
+@keyframes slide-in {
+    from {
+        transform: translateX(100%);
+        opacity: 0;
+    }
+    to {
+        transform: translateX(0);
+        opacity: 1;
+    }
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-10px);
+    }
+}

--- a/js/script.js
+++ b/js/script.js
@@ -77,4 +77,19 @@ document.addEventListener('DOMContentLoaded', function() {
         };
         updateCount();
     });
+
+    // Floating phone bubble and WhatsApp chat button
+    const phoneBubble = document.createElement('div');
+    phoneBubble.className = 'phone-bubble';
+    phoneBubble.innerHTML = '<a href="tel:0123-456-7890">0123-456-7890</a>';
+    document.body.appendChild(phoneBubble);
+
+    const whatsappBtn = document.createElement('a');
+    whatsappBtn.className = 'whatsapp-chat';
+    whatsappBtn.href = 'https://wa.me/01234567890';
+    whatsappBtn.target = '_blank';
+    whatsappBtn.rel = 'noopener';
+    whatsappBtn.setAttribute('aria-label', 'Chat on WhatsApp');
+    whatsappBtn.innerHTML = '<i class="fab fa-whatsapp"></i>';
+    document.body.appendChild(whatsappBtn);
 });


### PR DESCRIPTION
## Summary
- Add animated floating phone number bubble to all pages
- Introduce WhatsApp chat button for direct messaging

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c2b7f332f4832b8938818d2bb4aa09