### PR TITLE
feat: Add 'About Us' section to the homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -933,3 +933,46 @@ footer h3 {
         transform: translateY(-10px);
     }
 }
+
+/* About Us Section */
+.about-us-section {
+    padding: 3rem 0;
+}
+
+.about-us-section h2 {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.about-us-section h3 {
+    text-align: center;
+    margin-bottom: 2rem;
+    color: var(--accent-color);
+}
+
+.about-us-section .container p {
+    color: var(--dark-gray);
+}
+
+.about-us-images {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    margin: 2rem 0;
+}
+
+.about-us-images img {
+    border-radius: 5px;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+}
+
+.about-us-images img:hover {
+    transform: scale(1.05);
+}
+
+@media (min-width: 768px) {
+    .about-us-images {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <base href="./">
     <link rel="stylesheet" href="css/style.css">
     <script type="application/ld+json">
     {
@@ -121,6 +122,20 @@
                     <div class="stat-number counter" data-target="23">0</div>
                     <p class="stat-label">Avg Attending Time (Min)</p>
                 </div>
+            </div>
+        </section>
+
+        <section class="about-us-section">
+            <div class="container">
+                <h2>ABOUT OUR LOCKSMITH COMPANY</h2>
+                <h3>Still Looking for "Local Locksmiths Near Me?"</h3>
+                <p>You found Us. We offer professional Locksmith services throughout London. We are always concerned with offering the best local locksmith services in London on the market. This can be achieved by offering immediate assistance to all our customers, using cutting-edge technologies when we help them and offering effective help everytime we are asked to assist them. Our customers can call us for regular maintenance of their door locks and if they want to upgrade those which are worn out. Being a local business, we can get to any address in approximately 30 minutes, with offices all around the city that help us provide our customers with unrivaled convenience. You’ll never need to wait long for one of our London locksmiths to arrive at your location.</p>
+                <div class="about-us-images">
+                    <img src="images/locksmith-fixing-a-door.jpg" alt="Locksmith fixing a door">
+                    <img src="images/locksmiths-for-cars.jpg" alt="Locksmiths for cars">
+                </div>
+                <p>In less than 20 minutes, our Local London Locksmiths will be at the address you required and will fix your problem in no time. It is difficult to find reliable and trustworthy locksmiths when you really need them. Our locksmith technicians are highly professional and follow a special work policy. Also, their wide experience and amazing skills give them the ability to perform impeccably, regardless of the gravity of your situation. There’s more: they are available 24/7 and phone advice is free-of-charge and commitment-free!</p>
+                <p class="phone-number">Call Now: <a href="tel:0123-456-7890">0123-456-7890</a></p>
             </div>
         </section>
 


### PR DESCRIPTION
This commit introduces a new "About Our Locksmith Company" section to the `index.html` page, positioned after the "Serving All London Areas" section.

The new section includes:
- SEO-friendly headings and content as provided.
- Two relevant images: `locksmith-fixing-a-door.jpg` and `locksmiths-for-cars.jpg`.
- A contact phone number.
- Custom styling for the section, including a hover effect on the images, to enhance user experience.

The implementation follows the existing structure and design of the website.