### PR TITLE
Fix mobile nav overlay stacking to restore toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -64,7 +64,7 @@ header {
     border-bottom: 1px solid var(--light-gray);
     position: sticky;
     top: 0;
-    z-index: 1000;
+    z-index: 1100;
 }
 
 header .container {
@@ -1041,13 +1041,13 @@ footer h3 {
 .mobile-nav-toggle.is-active .hamburger::before {
     top: 0;
     transform: rotate(45deg);
-    background-color: var(--secondary-color);
+    background-color: var(--primary-color);
 }
 
 .mobile-nav-toggle.is-active .hamburger::after {
     bottom: 0;
     transform: rotate(-45deg);
-    background-color: var(--secondary-color);
+    background-color: var(--primary-color);
 }
 
 


### PR DESCRIPTION
## Summary
- Raise header z-index so navigation stays above the mobile menu overlay
- Keep hamburger icon visible by using primary color when menu is open

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e41bbd14832bbdf7c3b2881497e4