### PR TITLE
Centralize contact info across site

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -113,7 +113,7 @@
                         <ul class="contact-details">
                             <li><strong>Phone:</strong> <a href="tel:0123-456-7890">0123-456-7890</a></li>
                             <li><strong>Email:</strong> <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></li>
-                            <li><strong>Address:</strong> 123 Locking St, London, UK</li>
+                            <li><strong>Address:</strong> <span class="contact-address">123 Locking St, London, UK</span></li>
                         </ul>
                         <div class="contact-map">
                             <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.323522285144!2d-0.1277583842303254!3d51.5073509796349!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604ce3da42a1b%3A0x2664222f6745340d!2sLondon%2C%20UK!5e0!3m2!1sen!2sus!4f120" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>

--- a/js/script.js
+++ b/js/script.js
@@ -1,10 +1,71 @@
+const CONTACT_INFO = {
+    phone: '0123-456-7890',
+    email: 'contact@locksmith.com',
+    address: {
+        street: '123 Locking St',
+        city: 'London',
+        postalCode: 'E1 6AN',
+        country: 'UK',
+        full: '123 Locking St, London, UK'
+    },
+    social: {
+        facebook: 'https://www.facebook.com/your-locksmith',
+        instagram: 'https://www.instagram.com/your-locksmith'
+    }
+};
+
 document.addEventListener('DOMContentLoaded', function() {
     // This script handles all the dynamic functionality for the website.
+    const phoneDigits = CONTACT_INFO.phone.replace(/[^0-9]/g, '');
 
     // Mobile navigation toggle
     const navToggle = document.querySelector('.mobile-nav-toggle');
     const mobileNav = document.querySelector('.mobile-nav');
     const header = document.querySelector('header');
+
+    // Update contact information across the page
+    document.querySelectorAll('a[href^="tel:"]').forEach(a => {
+        a.href = `tel:${phoneDigits}`;
+        if (/\d/.test(a.textContent)) {
+            a.textContent = a.textContent.replace(/[\d\-\s]+/, CONTACT_INFO.phone);
+        }
+    });
+
+    document.querySelectorAll('a[href^="mailto:"]').forEach(a => {
+        a.href = `mailto:${CONTACT_INFO.email}`;
+        if (a.textContent.includes('@')) {
+            a.textContent = CONTACT_INFO.email;
+        }
+    });
+
+    document.querySelectorAll('.contact-address').forEach(el => {
+        el.textContent = CONTACT_INFO.address.full;
+    });
+
+    document.querySelectorAll('a').forEach(a => {
+        if (a.querySelector('.fa-facebook-f')) {
+            a.href = CONTACT_INFO.social.facebook;
+        }
+        if (a.querySelector('.fa-instagram')) {
+            a.href = CONTACT_INFO.social.instagram;
+        }
+    });
+
+    document.querySelectorAll('script[type="application/ld+json"]').forEach(tag => {
+        try {
+            const data = JSON.parse(tag.textContent);
+            if (data['@type'] === 'Locksmith') {
+                data.telephone = CONTACT_INFO.phone;
+                data.address = data.address || {};
+                data.address.streetAddress = CONTACT_INFO.address.street;
+                data.address.addressLocality = CONTACT_INFO.address.city;
+                data.address.postalCode = CONTACT_INFO.address.postalCode;
+                data.address.addressCountry = CONTACT_INFO.address.country;
+                data.sameAs = [CONTACT_INFO.social.facebook, CONTACT_INFO.social.instagram];
+                tag.textContent = JSON.stringify(data, null, 2);
+            }
+        } catch (e) {}
+    });
 
     function setMobileNavOffset() {
         if (header && mobileNav) {
@@ -127,12 +188,12 @@ document.addEventListener('DOMContentLoaded', function() {
     // Floating phone bubble and WhatsApp chat button
     const phoneBubble = document.createElement('div');
     phoneBubble.className = 'phone-bubble';
-    phoneBubble.innerHTML = '<a href="tel:0123-456-7890">0123-456-7890</a>';
+    phoneBubble.innerHTML = `<a href="tel:${phoneDigits}">${CONTACT_INFO.phone}</a>`;
     document.body.appendChild(phoneBubble);
 
     const whatsappBtn = document.createElement('a');
     whatsappBtn.className = 'whatsapp-chat';
-    whatsappBtn.href = 'https://wa.me/01234567890';
+    whatsappBtn.href = `https://wa.me/${phoneDigits}`;
     whatsappBtn.target = '_blank';
     whatsappBtn.rel = 'noopener';
     whatsappBtn.setAttribute('aria-label', 'Chat on WhatsApp');

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -86,7 +86,7 @@
                 <p>We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated "Last Updated" date.</p>
 
                 <h3>Contact Us</h3>
-                <p>If you have questions about this Privacy Policy or wish to exercise your data protection rights, please contact us at <a href="mailto:contact@locksmith.com">contact@locksmith.com</a> or write to 123 Locking St, London, UK.</p>
+                <p>If you have questions about this Privacy Policy or wish to exercise your data protection rights, please contact us at <a href="mailto:contact@locksmith.com">contact@locksmith.com</a> or write to <span class="contact-address">123 Locking St, London, UK</span>.</p>
 
                 <p><em>Last Updated: January 1, 2025</em></p>
             </div>


### PR DESCRIPTION
## Summary
- centralize phone, email, address and social links via reusable CONTACT_INFO object
- populate telephone, email, address and social anchors dynamically across pages
- make address text dynamic on contact and privacy pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2e6da7468832b808d208e9d3992b4