### PR TITLE
Remove placeholder contact info in favor of script injection

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/contact.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -111,16 +111,16 @@
                         <h2>Contact Information</h2>
                         <p>For immediate assistance, please call us. We are available 24/7.</p>
                         <ul class="contact-details">
-                            <li><strong>Phone:</strong> <a href="tel:0123-456-7890">0123-456-7890</a></li>
-                            <li><strong>Email:</strong> <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></li>
-                            <li><strong>Address:</strong> <span class="contact-address">123 Locking St, London, UK</span></li>
+                            <li><strong>Phone:</strong> <a href="tel:"></a></li>
+                            <li><strong>Email:</strong> <a href="mailto:"></a></li>
+                            <li><strong>Address:</strong> <span class="contact-address"></span></li>
                         </ul>
                         <div class="contact-map">
                             <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.323522285144!2d-0.1277583842303254!3d51.5073509796349!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604ce3da42a1b%3A0x2664222f6745340d!2sLondon%2C%20UK!5e0!3m2!1sen!2sus!4f120" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
                         </div>
                         <div class="social-media">
-                            <a href="#"><i class="fab fa-facebook-f"></i></a>
-                            <a href="#"><i class="fab fa-instagram"></i></a>
+                            <a><i class="fab fa-facebook-f"></i></a>
+                            <a><i class="fab fa-instagram"></i></a>
                         </div>
                     </div>
                 </div>
@@ -152,11 +152,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -18,14 +18,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -47,8 +47,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -71,10 +71,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle" aria-label="Open navigation">
@@ -97,8 +97,8 @@
             <div class="container">
                 <h1>Your Trusted 24/7 Local Locksmith</h1>
                 <p>Locked out? Need a lock change? We are here to help, day or night.</p>
-                <p class="phone-number">Call Now: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                <a href="tel:0123-456-7890" class="cta-button">Call Now</a>
+                <p class="phone-number">Call Now: <a href="tel:"></a></p>
+                <a href="tel:" class="cta-button">Call Now</a>
             </div>
         </section>
 
@@ -137,7 +137,7 @@
                     <img src="images/locksmiths-for-cars.jpg" alt="Locksmiths for cars">
                 </div>
                 <p>In less than 20 minutes, our Local London Locksmiths will be at the address you required and will fix your problem in no time. It is difficult to find reliable and trustworthy locksmiths when you really need them. Our locksmith technicians are highly professional and follow a special work policy. Also, their wide experience and amazing skills give them the ability to perform impeccably, regardless of the gravity of your situation. There’s more: they are available 24/7 and phone advice is free-of-charge and commitment-free!</p>
-                <p class="phone-number">Call Now: <a href="tel:0123-456-7890">0123-456-7890</a></p>
+                <p class="phone-number">Call Now: <a href="tel:"></a></p>
             </div>
         </section>
 
@@ -228,7 +228,7 @@
         <section class="promo-banner fade-in-element">
             <div class="container">
                 <p class="promo-text">Book Now and get a <strong>10% OFF</strong> Discount</p>
-                <a href="tel:0123-456-7890" class="cta-button">Book Now</a>
+                <a href="tel:" class="cta-button">Book Now</a>
             </div>
         </section>
 
@@ -279,7 +279,7 @@
                         <h2>Trusted London Locksmith Services for Any Situation</h2>
                         <p>Whether you’re locked out of your home, office, or car, or looking to improve your property’s security with high-quality replacement locks and keys, we’ve got you covered. Our goal is to provide reliable products and services so you never have to deal with the stress of repeated lockouts or compromised security systems.</p>
                         <p>Explore our full range of services below, and feel free to contact us anytime for emergency locksmith assistance in London and beyond. Our expert team of professional locksmiths is always on hand, equipped with the experience and resources to ensure your complete satisfaction. We’ve successfully supported customers all across Greater London with a wide variety of locksmith issues. When you choose London Locksmith, you’ll notice the difference compared to less reliable companies.</p>
-                        <p>Call us today at: <a href="tel:0123-456-7890">0123-456-7890</a></p>
+                        <p>Call us today at: <a href="tel:"></a></p>
                     </div>
                 </div>
             </div>
@@ -580,12 +580,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/js/script.js
+++ b/js/script.js
@@ -28,12 +28,20 @@ document.addEventListener('DOMContentLoaded', function() {
         a.href = `tel:${phoneDigits}`;
         if (/\d/.test(a.textContent)) {
             a.textContent = a.textContent.replace(/[\d\-\s]+/, CONTACT_INFO.phone);
+        } else if (a.textContent.trim() !== '') {
+            a.textContent = `${a.textContent.trim()} ${CONTACT_INFO.phone}`.trim();
+        } else {
+            a.textContent = CONTACT_INFO.phone;
         }
     });
 
     document.querySelectorAll('a[href^="mailto:"]').forEach(a => {
         a.href = `mailto:${CONTACT_INFO.email}`;
         if (a.textContent.includes('@')) {
+            a.textContent = CONTACT_INFO.email;
+        } else if (a.textContent.trim() !== '') {
+            a.textContent = `${a.textContent.trim()} ${CONTACT_INFO.email}`.trim();
+        } else {
             a.textContent = CONTACT_INFO.email;
         }
     });

--- a/locations.html
+++ b/locations.html
@@ -67,10 +67,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -173,11 +173,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/bromley.html
+++ b/locations/bromley.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Bromley?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/camden.html
+++ b/locations/camden.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/camden.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Camden?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/croydon.html
+++ b/locations/croydon.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/croydon.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Croydon?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/dartford.html
+++ b/locations/dartford.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Dartford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/east-london.html
+++ b/locations/east-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in East London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/enfield.html
+++ b/locations/enfield.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Enfield?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/hackney.html
+++ b/locations/hackney.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/hackney.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Hackney?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/harrow.html
+++ b/locations/harrow.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/harrow.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Harrow?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/hounslow.html
+++ b/locations/hounslow.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Hounslow?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/ilford.html
+++ b/locations/ilford.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Ilford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/islington.html
+++ b/locations/islington.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/islington.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Islington?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/kensington.html
+++ b/locations/kensington.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/kensington.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Kensington?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/kingston-upon-thames.html
+++ b/locations/kingston-upon-thames.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Kingston upon Thames?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/luton.html
+++ b/locations/luton.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/luton.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Luton?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/north-london.html
+++ b/locations/north-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in North London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/north-west-london.html
+++ b/locations/north-west-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in North West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/romford.html
+++ b/locations/romford.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Romford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/south-east-london.html
+++ b/locations/south-east-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in South East London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/south-west-london.html
+++ b/locations/south-west-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in South West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/sutton.html
+++ b/locations/sutton.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Sutton?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/uxbridge.html
+++ b/locations/uxbridge.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Uxbridge?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/watford.html
+++ b/locations/watford.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Watford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/west-london.html
+++ b/locations/west-london.html
@@ -28,10 +28,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -70,7 +70,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -106,11 +106,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/locations/westminster.html
+++ b/locations/westminster.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/locations/westminster.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "areaServed": {
         "@type": "Place",
@@ -50,8 +50,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -74,10 +74,10 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
                 <div class="header-social">
-                    <a href="#"><i class="fab fa-facebook-f"></i></a>
-                    <a href="#"><i class="fab fa-instagram"></i></a>
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
                 </div>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
@@ -122,7 +122,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Westminster?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -28,7 +28,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -86,7 +86,7 @@
                 <p>We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated "Last Updated" date.</p>
 
                 <h3>Contact Us</h3>
-                <p>If you have questions about this Privacy Policy or wish to exercise your data protection rights, please contact us at <a href="mailto:contact@locksmith.com">contact@locksmith.com</a> or write to <span class="contact-address">123 Locking St, London, UK</span>.</p>
+                <p>If you have questions about this Privacy Policy or wish to exercise your data protection rights, please contact us at <a href="mailto:"></a> or write to <span class="contact-address"></span>.</p>
 
                 <p><em>Last Updated: January 1, 2025</em></p>
             </div>
@@ -112,11 +112,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services.html
+++ b/services.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -178,11 +178,11 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/car-lockout.html
+++ b/services/car-lockout.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/car-lockout.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -143,7 +143,7 @@
                 <div class="service-cta">
                     <h3>Locked Out of Your Car?</h3>
                     <p>Our mobile locksmiths will come to you. Call now for rapid assistance.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -168,12 +168,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/commercial-locksmith.html
+++ b/services/commercial-locksmith.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/commercial-locksmith.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -139,7 +139,7 @@
                 <div class="service-cta">
                     <h3>Enhance Your Business Security</h3>
                     <p>Schedule a consultation with our commercial security experts today.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -164,12 +164,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/emergency-locksmith.html
+++ b/services/emergency-locksmith.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/emergency-locksmith.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -142,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need Emergency Help?</h3>
                     <p>Don't wait. Call us now for immediate assistance.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -167,12 +167,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/key-cutting.html
+++ b/services/key-cutting.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/key-cutting.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -134,7 +134,7 @@
                 <div class="service-cta">
                     <h3>Need a Key Cut?</h3>
                     <p>We cut keys while you wait. Call us to book or visit our workshop.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/lock-replacement.html
+++ b/services/lock-replacement.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/lock-replacement.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -133,7 +133,7 @@
                 <div class="service-cta">
                     <h3>Want to Replace Your Locks?</h3>
                     <p>Contact us today for a free quote and security consultation.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -158,12 +158,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/residential-locksmith.html
+++ b/services/residential-locksmith.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/residential-locksmith.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -136,7 +136,7 @@
                 <div class="service-cta">
                     <h3>Need to Secure Your Home?</h3>
                     <p>For a comprehensive home security solution, give us a call today.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -161,12 +161,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/safe-opening.html
+++ b/services/safe-opening.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/safe-opening.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -134,7 +134,7 @@
                 <div class="service-cta">
                     <h3>Can't Open Your Safe?</h3>
                     <p>Our safe engineers are available to help. Call us for a confidential consultation.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/smart-lock-installation.html
+++ b/services/smart-lock-installation.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/smart-lock-installation.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -134,7 +134,7 @@
                 <div class="service-cta">
                     <h3>Ready for a Smart Lock?</h3>
                     <p>Call us to schedule a smart lock installation or get expert advice.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>

--- a/services/upvc-door-repairs.html
+++ b/services/upvc-door-repairs.html
@@ -17,14 +17,14 @@
       "image": "https://www.example.com/logo.jpg",
       "@id": "",
       "url": "https://www.example.com/services/upvc-door-repairs.html",
-      "telephone": "0123-456-7890",
+      "telephone": "",
       "priceRange": "$$",
       "address": {
         "@type": "PostalAddress",
-        "streetAddress": "123 Locking St",
-        "addressLocality": "London",
-        "postalCode": "E1 6AN",
-        "addressCountry": "UK"
+        "streetAddress": "",
+        "addressLocality": "",
+        "postalCode": "",
+        "addressCountry": ""
       },
       "geo": {
         "@type": "GeoCoordinates",
@@ -46,8 +46,8 @@
         "closes": "23:59"
       },
       "sameAs": [
-        "https://www.facebook.com/your-locksmith",
-        "https://www.twitter.com/your-locksmith"
+        "",
+        ""
       ]
     }
     </script>
@@ -70,7 +70,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:0123-456-7890">Call Us: 0123-456-7890</a>
+                <a href="tel:">Call Us: </a>
             </div>
             <button class="mobile-nav-toggle">&#9776;</button>
         </div>
@@ -134,7 +134,7 @@
                 <div class="service-cta">
                     <h3>Problems with a UPVC Door?</h3>
                     <p>Don't let a small problem become a big one. Call us for a free assessment.</p>
-                    <a href="tel:0123-456-7890" class="cta-button">Call Now: 0123-456-7890</a>
+                    <a href="tel:" class="cta-button">Call Now: </a>
                 </div>
             </div>
         </section>
@@ -159,12 +159,12 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:0123-456-7890">0123-456-7890</a></p>
-                    <p>Email: <a href="mailto:contact@locksmith.com">contact@locksmith.com</a></p>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
                     <div class="social-media">
-                        <a href="#"><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-facebook-f"></i></a>
                         <a href="#"><i class="fab fa-twitter"></i></a>
-                        <a href="#"><i class="fab fa-instagram"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- strip phone, email, address and social placeholders from all HTML files
- enhance main script to always inject contact details into empty links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e8431d9c832ba5b42755e7e22387