### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,6 +74,12 @@ header .container {
     flex-wrap: wrap;
 }
 
+.logo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .logo a {
     font-family: var(--heading-font);
     font-size: 1.8rem;
@@ -86,6 +92,31 @@ header .container {
     height: 80px;   /* increase height */
     object-fit: contain; /* keeps aspect ratio inside box */
 }
+
+.theme-toggle {
+    margin-top: 0.5rem;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    color: var(--primary-color);
+}
+
+.theme-toggle:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 2px;
+}
+
+body.dark-mode {
+    --primary-color: #FFFFFF;
+    --secondary-color: #0A2342;
+    --accent-color: #2CA58D;
+    --light-gray: #333333;
+    --dark-gray: #f4f4f4;
+    background-color: var(--secondary-color);
+    color: var(--dark-gray);
+}
+
 
 
 header nav {

--- a/js/script.js
+++ b/js/script.js
@@ -22,6 +22,30 @@ document.addEventListener('DOMContentLoaded', function() {
     const navToggle = document.querySelector('.mobile-nav-toggle');
     const mobileNav = document.querySelector('.mobile-nav');
     const header = document.querySelector('header');
+    const logo = header ? header.querySelector('.logo') : null;
+
+    const themeToggle = document.createElement('button');
+    themeToggle.className = 'theme-toggle';
+    themeToggle.setAttribute('aria-label', 'Toggle dark mode');
+    themeToggle.innerHTML = '<i class="fas fa-moon"></i>';
+    if (logo) {
+        logo.appendChild(themeToggle);
+    }
+
+    const setTheme = mode => {
+        document.body.classList.toggle('dark-mode', mode === 'dark');
+        themeToggle.innerHTML = mode === 'dark'
+            ? '<i class="fas fa-sun"></i>'
+            : '<i class="fas fa-moon"></i>';
+    };
+
+    setTheme(localStorage.getItem('theme') || 'light');
+
+    themeToggle.addEventListener('click', () => {
+        const newTheme = document.body.classList.contains('dark-mode') ? 'light' : 'dark';
+        setTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    });
 
     // Update contact information across the page
     document.querySelectorAll('a[href^="tel:"]').forEach(a => {


### PR DESCRIPTION
## Summary
- add dark mode CSS variables and toggle styling
- inject theme toggle button below the logo and persist choice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f0a35888832b83414a736a59e042