### PR TITLE
Ensure hero image scales to full size on all devices

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,11 +144,12 @@ header nav {
 .hero {
     background-image: linear-gradient(rgba(10, 35, 66, 0.7), rgba(10, 35, 66, 0.7)), url(../images/hero-background.png);
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     color: var(--secondary-color);
     padding: 8rem 0;
     text-align: center;
+    min-height: 100vh;
 }
 
 .hero h1 {


### PR DESCRIPTION
## Summary
- Adjust hero section background to use `background-size: contain` so the entire image is visible.
- Add a `min-height` to stretch the hero section to the viewport height on all devices.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f71b14d4832bad27b6185e1d52b5