### PR TITLE
Fix hero section background scaling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,7 +144,7 @@ header nav {
 .hero {
     background-image: linear-gradient(rgba(10, 35, 66, 0.7), rgba(10, 35, 66, 0.7)), url(../images/hero-background.png);
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     color: var(--secondary-color);
     padding: 8rem 0;


### PR DESCRIPTION
## Summary
- prevent hero section background image from being cropped by switching to `background-size: contain`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f823b74c832bb88b4c516a645cb6