### PR TITLE
feat: Create Coverage Area page and fix hero image

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -146,6 +146,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="services.html">Services</a></li>
                         <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                         <li><a href="privacy-policy.html">Privacy Policy</a></li>
                     </ul>

--- a/coverage-area.html
+++ b/coverage-area.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Coverage Area - Local Locksmith</title>
+    <meta name="description" content="We provide locksmith services across all of London and surrounding areas. See our full coverage area map.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/style.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Service",
+      "serviceType": "Locksmith",
+      "provider": {
+        "@type": "Locksmith",
+        "name": "Locksmith"
+      },
+      "areaServed": [
+        { "@type": "City", "name": "Islington" },
+        { "@type": "City", "name": "Camden" },
+        { "@type": "City", "name": "Westminster" },
+        { "@type": "City", "name": "Hackney" },
+        { "@type": "City", "name": "Kensington" },
+        { "@type": "City", "name": "Luton" },
+        { "@type": "City", "name": "Croydon" },
+        { "@type": "City", "name": "Harrow" },
+        { "@type": "City", "name": "West London" },
+        { "@type": "City", "name": "North London" },
+        { "@type": "City", "name": "North West London" },
+        { "@type": "City", "name": "East London" },
+        { "@type": "City", "name": "South West London" },
+        { "@type": "City", "name": "South East London" },
+        { "@type": "City", "name": "Watford" },
+        { "@type": "City", "name": "Enfield" },
+        { "@type": "City", "name": "Uxbridge" },
+        { "@type": "City", "name": "Ilford" },
+        { "@type": "City", "name": "Romford" },
+        { "@type": "City", "name": "Hounslow" },
+        { "@type": "City", "name": "Dartford" },
+        { "@type": "City", "name": "Kingston upon Thames" },
+        { "@type": "City", "name": "Sutton" },
+        { "@type": "City", "name": "Bromley" }
+      ],
+      "url": "https://www.example.com/locations.html",
+      "name": "Service Locations"
+    }
+    </script>
+</head>
+<body>
+
+    <header>
+        <div class="container">
+            <div class="logo">
+                <a href="index.html">
+                    <img src="images/website-logo.png" alt="Locksmith Logo">
+                </a>
+            </div>
+            <nav>
+                <ul>
+                    <li><a href="index.html">Home</a></li>
+                    <li><a href="services.html">Services</a></li>
+                    <li><a href="locations.html">Locations</a></li>
+                    <li><a href="contact.html">Contact Us</a></li>
+                </ul>
+            </nav>
+            <div class="header-phone">
+                <a href="tel:">Call Us: </a>
+                <div class="header-social">
+                    <a><i class="fab fa-facebook-f"></i></a>
+                    <a><i class="fab fa-instagram"></i></a>
+                </div>
+            </div>
+            <button class="mobile-nav-toggle">&#9776;</button>
+        </div>
+    </header>
+
+    <nav class="mobile-nav">
+        <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="services.html">Services</a></li>
+            <li><a href="locations.html">Locations</a></li>
+            <li><a href="contact.html">Contact Us</a></li>
+        </ul>
+    </nav>
+
+    <main class="service-page">
+        <section class="hero-small">
+            <div class="container">
+                <h1>Our Coverage Area</h1>
+                <p>We proudly serve all of London and its surrounding areas. See our full list of locations below.</p>
+            </div>
+        </section>
+
+        <section class="locations-list">
+            <div class="container">
+                <div class="tag-cloud">
+                    <span class="tag-large"><a href="locations/north-london.html">North London</a></span>
+                    <span class="tag-medium"><a href="locations/north-west-london.html">North West London</a></span>
+                    <span class="tag-small"><a href="locations/islington.html">Islington</a></span>
+                    <span class="tag-medium"><a href="locations/camden.html">Camden</a></span>
+                    <span class="tag-small"><a href="locations/hackney.html">Hackney</a></span>
+                    <span class="tag-large"><a href="locations/enfield.html">Enfield</a></span>
+                    <span class="tag-small"><a href="locations/harrow.html">Harrow</a></span>
+                    <span class="tag-large"><a href="locations/west-london.html">West London</a></span>
+                    <span class="tag-medium"><a href="locations/westminster.html">Westminster</a></span>
+                    <span class="tag-small"><a href="locations/kensington.html">Kensington</a></span>
+                    <span class="tag-medium"><a href="locations/hounslow.html">Hounslow</a></span>
+                    <span class="tag-small"><a href="locations/uxbridge.html">Uxbridge</a></span>
+                    <span class="tag-large"><a href="locations/east-london.html">East London</a></span>
+                    <span class="tag-small"><a href="locations/ilford.html">Ilford</a></span>
+                    <span class="tag-medium"><a href="locations/romford.html">Romford</a></span>
+                    <span class="tag-large"><a href="locations/south-west-london.html">South West London</a></span>
+                    <span class="tag-medium"><a href="locations/south-east-london.html">South East London</a></span>
+                    <span class="tag-small"><a href="locations/croydon.html">Croydon</a></span>
+                    <span class="tag-large"><a href="locations/kingston-upon-thames.html">Kingston upon Thames</a></span>
+                    <span class="tag-medium"><a href="locations/sutton.html">Sutton</a></span>
+                    <span class="tag-small"><a href="locations/bromley.html">Bromley</a></span>
+                    <span class="tag-medium"><a href="locations/luton.html">Luton</a></span>
+                    <span class="tag-large"><a href="locations/watford.html">Watford</a></span>
+                    <span class="tag-small"><a href="locations/dartford.html">Dartford</a></span>
+                </div>
+            </div>
+        </section>
+
+        <section class="service-content">
+            <div class="container">
+                <div class="service-description">
+                    <h2>Comprehensive Locksmith Services Across London</h2>
+                    <p>At our company, we are proud to offer comprehensive, reliable, and professional locksmith services across the entirety of London and its surrounding areas. Our extensive coverage ensures that no matter where you are located, a skilled and certified locksmith is never more than a 30-minute call away. We have strategically positioned our mobile units throughout the city, from the bustling streets of Central London to the quiet suburbs, ensuring rapid response times for all your emergency and routine locksmith needs. Our commitment is to provide peace of mind to all our clients, whether they are residential homeowners, commercial business operators, or drivers locked out of their vehicles.</p>
+                    <p>Our coverage spans all major regions of London. In North London, we serve areas from Islington to Enfield, providing everything from emergency lockout assistance to high-security lock installations. Our teams in West London, including Westminster and Kensington, are ready to handle sophisticated security upgrades for both homes and businesses. For those in East London, we offer rapid response for lock repairs and replacements. In South London, from Bromley to Kingston upon Thames, our locksmiths are equipped to handle any situation, including UPVC door and window lock issues. We also extend our services to the surrounding areas, including Luton, Watford, and Dartford, ensuring that even those on the outskirts of the city have access to top-quality locksmith services.</p>
+                    <p>We understand that lock-related issues can be stressful and often occur at the most inconvenient times. That's why our services are available 24 hours a day, 7 days a week. Our team of highly trained and experienced locksmiths is equipped with the latest tools and technology to handle any job, big or small. We specialize in a wide range of services, including residential and commercial lock changes, emergency car lockouts, key cutting, safe opening, and the installation of smart lock systems. All our technicians are DBS checked, and we pride ourselves on our transparent pricing and commitment to customer satisfaction. Every service call is an opportunity for us to demonstrate our dedication to quality workmanship and exceptional customer care. Our 12-month guarantee on all parts and labor further underscores our promise of reliability and excellence. When you choose us, you are choosing a locksmith service that is dedicated to your safety and security.</p>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer>
+        <div class="container">
+            <div class="footer-flex">
+                <div class="footer-about">
+                    <h3>Locksmith</h3>
+                    <p>Your local, reliable locksmith service. Available 24/7 for all your locksmith needs.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Links</h3>
+                    <ul>
+                        <li><a href="index.html">Home</a></li>
+                        <li><a href="services.html">Services</a></li>
+                        <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
+                        <li><a href="contact.html">Contact Us</a></li>
+                        <li><a href="privacy-policy.html">Privacy Policy</a></li>
+                    </ul>
+                </div>
+                <div class="footer-contact">
+                    <h3>Contact Us</h3>
+                    <p>Call Us: <a href="tel:"></a></p>
+                    <p>Email: <a href="mailto:"></a></p>
+                    <div class="social-media">
+                        <a><i class="fab fa-facebook-f"></i></a>
+                        <a><i class="fab fa-instagram"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="copyright">
+                <p>&copy; 2025 Locksmith. All Rights Reserved.</p>
+            </div>
+        </div>
+    </footer>
+
+    <script src="js/script.js"></script>
+</body>
+</html>

--- a/css/style.css
+++ b/css/style.css
@@ -142,13 +142,19 @@ header nav {
 
 /* Hero Section */
 .hero {
-    background-image: linear-gradient(rgba(10, 35, 66, 0.7), rgba(10, 35, 66, 0.7)), url(../images/hero-background.png);
+    background-image: linear-gradient(rgba(10, 35, 66, 0.7), rgba(10, 35, 66, 0.7)), url(../images/locksmith-fixing-a-door.jpg);
     background-repeat: no-repeat;
-    background-size: cover;
+    background-size: contain;
     background-position: center;
     color: var(--secondary-color);
-    padding: 8rem 0;
+    padding: 2rem 0;
     text-align: center;
+    min-height: 400px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--primary-color);
 }
 
 .hero h1 {
@@ -803,6 +809,43 @@ footer h3 {
 /* Locations Page Specific Styles */
 .locations-list {
     padding: 3rem 0;
+}
+
+.tag-cloud {
+    text-align: center;
+    padding: 2rem 0;
+}
+
+.tag-cloud a {
+    display: inline-block;
+    padding: 0.5rem 1rem;
+    margin: 0.5rem;
+    border-radius: 25px;
+    background-color: var(--light-gray);
+    color: var(--primary-color);
+    transition: all 0.3s ease;
+    text-decoration: none;
+}
+
+.tag-cloud a:hover {
+    background-color: var(--accent-color);
+    color: var(--secondary-color);
+    transform: scale(1.1);
+}
+
+.tag-cloud .tag-large a {
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.tag-cloud .tag-medium a {
+    font-size: 1.2rem;
+    font-weight: 500;
+}
+
+.tag-cloud .tag-small a {
+    font-size: 1rem;
+    font-weight: 400;
 }
 
 .area-group {

--- a/index.html
+++ b/index.html
@@ -576,11 +576,12 @@
                 <div class="footer-links">
                     <h3>Quick Links</h3>
                     <ul>
-                        <li><a href="../index.html">Home</a></li>
-                        <li><a href="../services.html">Services</a></li>
-                        <li><a href="../locations.html">Locations</a></li>
-                        <li><a href="../contact.html">Contact Us</a></li>
-                        <li><a href="../privacy-policy.html">Privacy Policy</a></li>
+                        <li><a href="index.html">Home</a></li>
+                        <li><a href="services.html">Services</a></li>
+                        <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
+                        <li><a href="contact.html">Contact Us</a></li>
+                        <li><a href="privacy-policy.html">Privacy Policy</a></li>
                     </ul>
                 </div>
                 <div class="footer-contact">

--- a/locations.html
+++ b/locations.html
@@ -167,6 +167,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="services.html">Services</a></li>
                         <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                         <li><a href="privacy-policy.html">Privacy Policy</a></li>
                     </ul>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -106,6 +106,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="services.html">Services</a></li>
                         <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                         <li><a href="privacy-policy.html">Privacy Policy</a></li>
                     </ul>

--- a/services.html
+++ b/services.html
@@ -172,6 +172,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="services.html">Services</a></li>
                         <li><a href="locations.html">Locations</a></li>
+                        <li><a href="coverage-area.html">Coverage Area</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                         <li><a href="privacy-policy.html">Privacy Policy</a></li>
                     </ul>


### PR DESCRIPTION
This commit introduces a new "Coverage Area" page and fixes a display issue with the hero image on the homepage.

The new `coverage-area.html` page provides a visually engaging "tag cloud" of all the service locations, as a "cooler" alternative to a map, which was not feasible with the available assets. The page also includes informational text about the company's services and coverage. A link to the new page has been added to the footer of all pages for consistent navigation.

The hero image on the `index.html` page has been fixed to ensure it is always fully visible and not cut off. This was achieved by updating the CSS to use `background-size: contain` and ensuring a valid image file is used.