### PR TITLE
Hide phone bubble on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1255,6 +1255,12 @@ footer h3 {
     background-color: #1ebe5d;
 }
 
+@media (max-width: 768px) {
+    .phone-bubble {
+        display: none;
+    }
+}
+
 @keyframes slide-in {
     from {
         transform: translateX(100%);


### PR DESCRIPTION
## Summary
- hide phone bubble on small screens with a max-width media query

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68c3f1870f0c832bafa344812adf9277