### PR TITLE
Add local CAPTCHA, email backend, and SEO improvements

### DIFF
--- a/config/email.json
+++ b/config/email.json
@@ -1,0 +1,10 @@
+{
+  "host": "",
+  "port": 587,
+  "secure": false,
+  "auth": {
+    "user": "",
+    "pass": ""
+  },
+  "to": ""
+}

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Contact Us - 24/7 Local Locksmith</title>
     <meta name="description" content="Contact your local locksmith for 24/7 emergency service, quotes, or any inquiries. Call us, email us, or use our contact form.">
+    <meta name="robots" content="index, follow">
+    <meta name="keywords" content="locksmith contact, locksmith quote, emergency locksmith">
+    <meta name="author" content="Locksmith">
+    <link rel="canonical" href="https://www.example.com/contact.html">
+    <meta property="og:title" content="Contact Us - 24/7 Local Locksmith">
+    <meta property="og:description" content="Contact your local locksmith for 24/7 emergency service, quotes, or any inquiries.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.example.com/contact.html">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
@@ -74,6 +82,12 @@
                             <input type="email" name="email" placeholder="Your Email" required>
                             <input type="tel" name="phone" placeholder="Your Phone Number">
                             <textarea name="message" rows="6" placeholder="Your Message" required></textarea>
+                            <div class="captcha-wrapper">
+                                <img class="captcha-image" alt="CAPTCHA">
+                                <button type="button" class="refresh-captcha" aria-label="Refresh captcha">&#8635;</button>
+                            </div>
+                            <input type="hidden" name="captchaToken">
+                            <input type="text" name="captchaValue" placeholder="Enter CAPTCHA" required>
                             <button type="submit" class="cta-button">Send Message</button>
                         </form>
                     </div>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Your Local Locksmith - Fast & Reliable 24/7 Service</title>
     <meta name="description" content="Your Local Locksmith offers fast and reliable 24/7 emergency locksmith services. We specialize in lockouts, lock changes, car key replacements, and more.">
+    <meta name="robots" content="index, follow">
+    <meta name="keywords" content="locksmith, emergency locksmith, 24/7 locksmith, lock change, car lockout">
+    <meta name="author" content="Locksmith">
+    <link rel="canonical" href="https://www.example.com/">
+    <meta property="og:title" content="Your Local Locksmith - Fast & Reliable 24/7 Service">
+    <meta property="og:description" content="Your Local Locksmith offers fast and reliable 24/7 emergency locksmith services across London.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://www.example.com/">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
@@ -519,6 +527,12 @@
                             <input type="text" name="name" placeholder="Your Name" required>
                             <input type="email" name="email" placeholder="Your Email" required>
                             <textarea name="message" placeholder="Your Message" required></textarea>
+                            <div class="captcha-wrapper">
+                                <img class="captcha-image" alt="CAPTCHA">
+                                <button type="button" class="refresh-captcha" aria-label="Refresh captcha">&#8635;</button>
+                            </div>
+                            <input type="hidden" name="captchaToken">
+                            <input type="text" name="captchaValue" placeholder="Enter CAPTCHA" required>
                             <button type="submit" class="cta-button">Send Message</button>
                         </form>
                     </div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "locksmithweb",
+  "version": "1.0.0",
+  "description": "Locksmith website with contact form backend",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('No tests specified')\""
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
+    "helmet": "^7.0.0",
+    "nodemailer": "^6.9.3",
+    "svg-captcha": "^1.4.0"
+  }
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow:
+Sitemap: https://www.example.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Improve SEO with canonical links, keywords, and a robots.txt sitemap
- Add local image CAPTCHA to all contact forms with client-side handling
- Introduce Express backend with security middleware and email sending using configurable SMTP settings

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/express)*
- `npm test`
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68c3f32529d0832ba2a8351c1f767085