### PR TITLE
feat: support offline captcha

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -77,7 +77,7 @@
                         <h2>Send Us a Message</h2>
                         <p>Have a question or need a quote? Fill out the form below and we'll get back to you as soon as possible.</p>
                         <p>Our team serves all London boroughs and is on call 24/7 for emergencies.</p>
-                        <form action="#" method="post">
+                        <form action="/contact" method="post">
                             <input type="text" name="name" placeholder="Your Name" required>
                             <input type="email" name="email" placeholder="Your Email" required>
                             <input type="tel" name="phone" placeholder="Your Phone Number">

--- a/index.html
+++ b/index.html
@@ -523,7 +523,7 @@
                 <h2>Contact Us</h2>
                 <div class="contact-flex">
                     <div class="contact-form">
-                        <form action="#" method="post">
+                        <form action="/contact" method="post">
                             <input type="text" name="name" placeholder="Your Name" required>
                             <input type="email" name="email" placeholder="Your Email" required>
                             <textarea name="message" placeholder="Your Message" required></textarea>

--- a/js/main.js
+++ b/js/main.js
@@ -213,6 +213,14 @@ function initSite() {
 
         async function loadCaptcha() {
             try {
+                if (location.protocol === 'file:') {
+                    const text = Math.random().toString(36).substring(2, 8);
+                    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="100" height="40"><rect width="100%" height="100%" fill="#eee"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="24" fill="#555">${text}</text></svg>`;
+                    captchaImg.src = `data:image/svg+xml;base64,${btoa(svg)}`;
+                    captchaImg.dataset.answer = text;
+                    captchaToken.value = 'local';
+                    return;
+                }
                 const res = await fetch('/captcha');
                 const data = await res.json();
                 captchaImg.src = data.image;
@@ -230,6 +238,18 @@ function initSite() {
         form.addEventListener('submit', async e => {
             e.preventDefault();
             const formData = new FormData(form);
+            if (location.protocol === 'file:') {
+                const answer = captchaImg.dataset.answer || '';
+                if (captchaInput.value.trim().toLowerCase() !== answer.toLowerCase()) {
+                    alert('Invalid captcha');
+                    loadCaptcha();
+                    return;
+                }
+                alert('Form submission is disabled in local preview.');
+                form.reset();
+                loadCaptcha();
+                return;
+            }
             try {
                 const res = await fetch('/contact', {
                     method: 'POST',


### PR DESCRIPTION
## Summary
- allow captcha to render when viewing pages from local file system
- send contact forms to `/contact` endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3f46eb65c832ba65ce5477923dc1f