### PR TITLE
Add 404 page and serve for unmatched requests

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Page Not Found</title>
+  <style>
+    body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; }
+    a { color: #007bff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>404 - Page Not Found</h1>
+  <p>The page you're looking for doesn't exist.</p>
+  <p><a href="/index.html">Return to Home</a></p>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -108,6 +108,14 @@ app.post(
   }
 );
 
+// 404 handler for unmatched GET requests
+app.use((req, res) => {
+  if (req.method === 'GET') {
+    return res.status(404).sendFile(path.join(__dirname, '404.html'));
+  }
+  res.status(404).send('Not Found');
+});
+
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- add simple 404.html page with link back to index
- serve 404 page for unmatched GET requests in Express server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c3fd59f5a4832b8971725fd88fd8e2