### PR TITLE
Fix mobile counter animation parsing issue

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -188,7 +188,7 @@ function initSite() {
     counters.forEach(counter => {
         const updateCount = () => {
             const target = +counter.getAttribute('data-target');
-            const count = +counter.innerText.replace(/,/g, '');
+            const count = parseInt(counter.innerText.replace(/\D/g, ''), 10) || 0;
             const increment = target / 200;
             if (count < target) {
                 counter.innerText = Math.ceil(count + increment).toLocaleString();


### PR DESCRIPTION
## Summary
- Avoid infinite counter animation on mobile by parsing digits only for stat counters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c612f8f348832b9c00bd28f888e95d