### PR TITLE
Prevent horizontal scrolling on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,13 @@ body {
     margin: 0;
 }
 
+@media (max-width: 768px) {
+    html,
+    body {
+        overflow-x: hidden;
+    }
+}
+
 .container {
     max-width: 1200px;
     margin: 0 auto;


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on mobile devices by hiding horizontal overflow on the page root elements

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c90c28bb98832b8641fdb49f7948d3