### PR TITLE
Enable mailto-based contact form and remove homepage form

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -77,19 +77,14 @@
                         <h2>Send Us a Message</h2>
                         <p>Have a question or need a quote? Fill out the form below and we'll get back to you as soon as possible.</p>
                         <p>Our team serves all London boroughs and is on call 24/7 for emergencies.</p>
-                        <form action="/contact" method="post">
+                        <form class="contact-email-form" data-mailto-form>
                             <input type="text" name="name" placeholder="Your Name" required>
                             <input type="email" name="email" placeholder="Your Email" required>
                             <input type="tel" name="phone" placeholder="Your Phone Number">
                             <textarea name="message" rows="6" placeholder="Your Message" required></textarea>
-                            <div class="captcha-wrapper">
-                                <img class="captcha-image" alt="CAPTCHA">
-                                <button type="button" class="refresh-captcha" aria-label="Refresh captcha"><i class="fas fa-sync-alt"></i></button>
-                            </div>
-                            <input type="hidden" name="captchaToken">
-                            <input type="text" name="captchaValue" placeholder="Enter CAPTCHA" required>
                             <button type="submit" class="cta-button">Send Message</button>
                         </form>
+                        <p class="form-note">Submitting will open your email app with the details pre-filled so you can send the message directly.</p>
                     </div>
                     <div class="contact-info-container">
                         <h2>Contact Information</h2>

--- a/index.html
+++ b/index.html
@@ -518,30 +518,7 @@
             </div>
         </section>
 
-        <section class="contact-section fade-in-element">
-            <div class="container">
-                <h2>Contact Us</h2>
-                <div class="contact-flex">
-                    <div class="contact-form">
-                        <form action="/contact" method="post">
-                            <input type="text" name="name" placeholder="Your Name" required>
-                            <input type="email" name="email" placeholder="Your Email" required>
-                            <textarea name="message" placeholder="Your Message" required></textarea>
-                            <div class="captcha-wrapper">
-                                <img class="captcha-image" alt="CAPTCHA">
-                                <button type="button" class="refresh-captcha" aria-label="Refresh captcha"><i class="fas fa-sync-alt"></i></button>
-                            </div>
-                            <input type="hidden" name="captchaToken">
-                            <input type="text" name="captchaValue" placeholder="Enter CAPTCHA" required>
-                            <button type="submit" class="cta-button">Send Message</button>
-                        </form>
-                    </div>
-                    <div class="contact-map">
-                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2483.323522285144!2d-0.1277583842303254!3d51.5073509796349!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x487604ce3da42a1b%3A0x2664222f6745340d!2sLondon%2C%20UK!5e0!3m2!1sen!2sus!4f120" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
-                    </div>
-                </div>
-            </div>
-        </section>
+        
     </main>
 
     


### PR DESCRIPTION
## Summary
- remove the non-functional contact form from the homepage
- update the contact page markup to use a mailto-based workflow and add guidance text
- replace the captcha/post submission script with logic that opens the visitor's email client

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d647107604832b9667032efd0a0faf