### PR TITLE
Fix coverage area map styling

### DIFF
--- a/coverage-area.html
+++ b/coverage-area.html
@@ -24,6 +24,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@700&family=Roboto:wght@400;500&display=swap" rel="stylesheet">
+    <link rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-sA+e2atLYY2l7LMpPZpMERZbBsao7Gzp0CM0iZqE0Xk="
+          crossorigin="anonymous">
     <link rel="stylesheet" href="css/style.css">
     <script type="application/ld+json">
 {


### PR DESCRIPTION
## Summary
- include the Leaflet CSS bundle on the coverage area page so map tiles render correctly

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d6632d4fd0832b95bcb2949c0cca60