### PR TITLE
Add Google Ads conversion tracking

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -22,6 +22,17 @@ const CONTACT_INFO = {
 
 function initSite() {
     // This script handles all the dynamic functionality for the website.
+    const googleAdsConfig = window.GOOGLE_ADS_CONFIG || {
+        conversionId: 'AW-17608473030',
+        phoneConversionLabel: 'AW-17608473030/LABEL_PHONE',
+        whatsappConversionLabel: 'AW-17608473030/LABEL_WHATSAPP'
+    };
+    const phoneConversionAttribute = googleAdsConfig.phoneConversionLabel
+        ? `if(window.gtag){gtag('event','conversion',{'send_to':'${googleAdsConfig.phoneConversionLabel}'});}`
+        : '';
+    const whatsappConversionAttribute = googleAdsConfig.whatsappConversionLabel
+        ? `if(window.gtag){gtag('event','conversion',{'send_to':'${googleAdsConfig.whatsappConversionLabel}'});}`
+        : '';
     const phoneFormats = CONTACT_INFO.phone;
     const phoneLinks = new Set();
     const localDialString = phoneFormats.local;
@@ -71,6 +82,10 @@ function initSite() {
         }
 
         phoneLinks.add(link);
+
+        if (phoneConversionAttribute) {
+            link.setAttribute('onclick', phoneConversionAttribute);
+        }
     }
 
     function applyPhoneHrefByCountry(countryCode) {
@@ -318,6 +333,9 @@ function initSite() {
     whatsappBtn.rel = 'noopener';
     whatsappBtn.setAttribute('aria-label', 'Chat on WhatsApp');
     whatsappBtn.innerHTML = '<i class="fab fa-whatsapp"></i>';
+    if (whatsappConversionAttribute) {
+        whatsappBtn.setAttribute('onclick', whatsappConversionAttribute);
+    }
     document.body.appendChild(whatsappBtn);
 
     const whatsappLinkSelectors = ['a[href*="wa.me"]', 'a[href*="api.whatsapp.com"]'];
@@ -333,6 +351,9 @@ function initSite() {
         link.rel = Array.from(relTokens).join(' ');
         if (!link.hasAttribute('target')) {
             link.setAttribute('target', '_blank');
+        }
+        if (whatsappConversionAttribute) {
+            link.setAttribute('onclick', whatsappConversionAttribute);
         }
     });
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,36 @@
 const ROOT_URL = new URL('..', document.currentScript.src);
+const GOOGLE_ADS_CONVERSION_ID = 'AW-17608473030';
+
+(function initGoogleAdsGlobalSiteTag() {
+    if (typeof document === 'undefined') {
+        return;
+    }
+
+    if (!document.querySelector(`script[src*="${GOOGLE_ADS_CONVERSION_ID}"]`)) {
+        const head = document.head || document.querySelector('head') || document.documentElement;
+        const gtagScript = document.createElement('script');
+        gtagScript.async = true;
+        gtagScript.src = `https://www.googletagmanager.com/gtag/js?id=${GOOGLE_ADS_CONVERSION_ID}`;
+        head.appendChild(gtagScript);
+    }
+
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = window.gtag || function gtag() {
+        window.dataLayer.push(arguments);
+    };
+
+    window.gtag('js', new Date());
+    window.gtag('config', GOOGLE_ADS_CONVERSION_ID);
+})();
+
+if (!window.GOOGLE_ADS_CONFIG) {
+    // TODO: Replace the conversion label placeholders with the actual values from Google Ads.
+    window.GOOGLE_ADS_CONFIG = {
+        conversionId: GOOGLE_ADS_CONVERSION_ID,
+        phoneConversionLabel: 'AW-17608473030/LABEL_PHONE',
+        whatsappConversionLabel: 'AW-17608473030/LABEL_WHATSAPP'
+    };
+}
 
 const NAVBAR_HTML = `<header>
     <div class="container">


### PR DESCRIPTION
## Summary
- inject the Google Ads global site tag so the gtag loader and configuration are added to the document head on every page load
- expose configurable Google Ads conversion labels and apply inline onclick conversion tracking to all phone and WhatsApp links

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9683f7f94832b98fc4e80676836d6