### PR TITLE
Add Google Ads conversion tracking tag

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/contact.html
+++ b/contact.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -68,20 +92,6 @@
   ]
 }
     </script>
-    <script>
-function gtag_report_conversion(url) {
-  var callback = function () {
-    if (typeof(url) != 'undefined') {
-      window.location = url;
-    }
-  };
-  gtag('event', 'conversion', {
-      'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
-      'event_callback': callback
-  });
-  return false;
-}
-</script>
 </head>
 <body>
     <div id="navbar-placeholder"></div>
@@ -113,7 +123,7 @@ function gtag_report_conversion(url) {
                         <h2>Contact Information</h2>
                         <p>For immediate assistance, please call us. We are available 24/7.</p>
                         <ul class="contact-details">
-                            <li><strong>Phone:</strong> <a href="tel:02039513549">02039513549</a></li>
+                            <li><strong>Phone:</strong> <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a></li>
                             <li><strong>Email:</strong> <a href="mailto:contact@lockersmith.co.uk">contact@lockersmith.co.uk</a></li>
                             <li><strong>Address:</strong> <span class="contact-address"></span></li>
                         </ul>

--- a/coverage-area.html
+++ b/coverage-area.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/coverage-areaTEST.html
+++ b/coverage-areaTEST.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -89,7 +113,7 @@
                 </ul>
             </nav>
             <div class="header-phone">
-                <a href="tel:+447757666691">+44 7757 666 691</a>
+                <a href="tel:+447757666691" onclick="return gtag_report_conversion(this.href);">+44 7757 666 691</a>
                 <div class="header-social">
                     <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>
                     <a href="https://www.instagram.com/lockersmithuk/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
@@ -185,7 +209,7 @@
                 </div>
                 <div class="footer-contact">
                     <h3>Contact Us</h3>
-                    <p>Call Us: <a href="tel:+447757666691">+44 7757 666 691</a></p>
+                    <p>Call Us: <a href="tel:+447757666691" onclick="return gtag_report_conversion(this.href);">+44 7757 666 691</a></p>
                     <p>Email: <a href="mailto:contact@lockersmith.co.uk">contact@lockersmith.co.uk</a></p>
                     <div class="social-media">
                         <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>

--- a/footer.html
+++ b/footer.html
@@ -18,7 +18,7 @@
             </div>
             <div class="footer-contact">
                 <h3>Contact Us</h3>
-                <p>Call Us: <a href="tel:02039513549">02039513549</a></p>
+                <p>Call Us: <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a></p>
                 <p>Email: <a href="mailto:contact@lockersmith.co.uk">contact@lockersmith.co.uk</a></p>
                 <div class="social-media">
                     <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -132,23 +156,6 @@
   ]
 }
     </script>
-    <!-- Event snippet for Contact conversion page
-In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
-<script>
-function gtag_report_conversion(url) {
-  var callback = function () {
-    if (typeof(url) != 'undefined') {
-      window.location = url;
-    }
-  };
-  gtag('event', 'conversion', {
-      'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
-      'event_callback': callback
-  });
-  return false;
-}
-</script>
-
 </head>
 <body>
     <div id="navbar-placeholder"></div>
@@ -159,7 +166,7 @@ function gtag_report_conversion(url) {
                 <h1>24/7 Locker Smith Locksmiths in London</h1>
                 <p>Locked out of your house, car or office? Call Locker Smith for rapid, damage-free entry and security upgrades anywhere in Greater London.</p>
                 <div class="hero-phone-container">
-                    <a href="tel:02039513549" class="hero-phone-button" aria-label="Call 02039513549">
+                    <a href="tel:02039513549" class="hero-phone-button" aria-label="Call 02039513549" onclick="return gtag_report_conversion(this.href);">
                         <i class="fas fa-phone-alt"></i>
                         <span class="phone-number-text">02039513549</span>
                     </a>
@@ -204,7 +211,7 @@ function gtag_report_conversion(url) {
                     <img src="images/locksmiths-for-cars.jpg" alt="Automotive locksmith from Locker Smith unlocking a car in London">
                 </div>
                 <p>In less than 30 minutes, a Locker Smith locksmith can be by your side with an ID badge, uniform and an extensively stocked van. Every technician is trained in smart lock technology, British Standard BS3621 installation and non-destructive entry so you never have to compromise security for speed.</p>
-                <p class="phone-number">Call Now: <a href="tel:02039513549">02039513549</a></p>
+                <p class="phone-number">Call Now: <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a></p>
             </div>
         </section>
 
@@ -304,7 +311,7 @@ function gtag_report_conversion(url) {
         <section class="promo-banner fade-in-element">
             <div class="container">
                 <p class="promo-text">Book Now and get a <strong>10% OFF</strong> Discount</p>
-                <a href="tel:02039513549" class="cta-button">Book Now</a>
+                <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Book Now</a>
             </div>
         </section>
 
@@ -355,7 +362,7 @@ function gtag_report_conversion(url) {
                         <h2>Trusted Locker Smith Services for Any Situation</h2>
                         <p>Whether you’re locked out of your home, office, or car, or looking to improve your property’s security with high-quality replacement locks and keys, Locker Smith has you covered. Our goal is to provide reliable products and services so you never have to deal with the stress of repeated lockouts or compromised security systems.</p>
                         <p>Explore our full range of services below, and feel free to contact us anytime for emergency locksmith assistance in London and the surrounding counties. Our expert team of professional locksmiths is always on hand, equipped with the experience and resources to ensure your complete satisfaction. We’ve successfully supported customers across Greater London with a wide variety of locksmith issues. When you choose Locker Smith, you’ll notice the difference compared to less reliable companies.</p>
-                        <p>Call us today at: <a href="tel:02039513549">02039513549</a></p>
+                        <p>Call us today at: <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a></p>
                     </div>
                 </div>
             </div>
@@ -401,7 +408,7 @@ function gtag_report_conversion(url) {
                         </ul>
                     </div>
                 </div>
-                <p class="area-cta">Need a locksmith in your area? Call <a href="tel:02039513549">02039513549</a> or <a href="contact.html">request a callback</a> and our nearest engineer will be dispatched immediately.</p>
+                <p class="area-cta">Need a locksmith in your area? Call <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a> or <a href="contact.html">request a callback</a> and our nearest engineer will be dispatched immediately.</p>
             </div>
         </section>
 

--- a/js/main.js
+++ b/js/main.js
@@ -28,7 +28,7 @@ function initSite() {
         whatsappConversionLabel: 'AW-17608473030/LABEL_WHATSAPP'
     };
     const phoneConversionAttribute = googleAdsConfig.phoneConversionLabel
-        ? `if(window.gtag){gtag('event','conversion',{'send_to':'${googleAdsConfig.phoneConversionLabel}'});}`
+        ? "return gtag_report_conversion(this.href);"
         : '';
     const whatsappConversionAttribute = googleAdsConfig.whatsappConversionLabel
         ? `if(window.gtag){gtag('event','conversion',{'send_to':'${googleAdsConfig.whatsappConversionLabel}'});}`

--- a/js/script.js
+++ b/js/script.js
@@ -27,7 +27,7 @@ if (!window.GOOGLE_ADS_CONFIG) {
     // TODO: Replace the conversion label placeholders with the actual values from Google Ads.
     window.GOOGLE_ADS_CONFIG = {
         conversionId: GOOGLE_ADS_CONVERSION_ID,
-        phoneConversionLabel: 'AW-17608473030/LABEL_PHONE',
+        phoneConversionLabel: 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
         whatsappConversionLabel: 'AW-17608473030/LABEL_WHATSAPP'
     };
 }
@@ -48,7 +48,7 @@ const NAVBAR_HTML = `<header>
             </ul>
         </nav>
         <div class="header-phone">
-            <a href="tel:02039513549">Call Us: 02039513549</a>
+            <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">Call Us: 02039513549</a>
             <div class="header-social">
                 <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>
                 <a href="https://www.instagram.com/lockersmithuk/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
@@ -89,7 +89,7 @@ const FOOTER_HTML = `<footer>
             </div>
             <div class="footer-contact">
                 <h3>Contact Us</h3>
-                <p>Call Us: <a href="tel:02039513549">02039513549</a></p>
+                <p>Call Us: <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a></p>
                 <p>Email: <a href="mailto:contact@lockersmith.co.uk">contact@lockersmith.co.uk</a></p>
                 <div class="social-media">
                     <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>

--- a/locations.html
+++ b/locations.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/locations/bromley.html
+++ b/locations/bromley.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Bromley?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/camden.html
+++ b/locations/camden.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Camden?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/croydon.html
+++ b/locations/croydon.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Croydon?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/dartford.html
+++ b/locations/dartford.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Dartford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/east-london.html
+++ b/locations/east-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in East London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/enfield.html
+++ b/locations/enfield.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Enfield?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/hackney.html
+++ b/locations/hackney.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Hackney?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/harrow.html
+++ b/locations/harrow.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Harrow?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/hounslow.html
+++ b/locations/hounslow.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Hounslow?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/ilford.html
+++ b/locations/ilford.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Ilford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/islington.html
+++ b/locations/islington.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Islington?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/kensington.html
+++ b/locations/kensington.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Kensington?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/kingston-upon-thames.html
+++ b/locations/kingston-upon-thames.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Kingston upon Thames?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/luton.html
+++ b/locations/luton.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Luton?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/north-london.html
+++ b/locations/north-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in North London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/north-west-london.html
+++ b/locations/north-west-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in North West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/romford.html
+++ b/locations/romford.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Romford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/south-east-london.html
+++ b/locations/south-east-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in South East London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/south-west-london.html
+++ b/locations/south-west-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in South West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/sutton.html
+++ b/locations/sutton.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Sutton?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/uxbridge.html
+++ b/locations/uxbridge.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Uxbridge?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/watford.html
+++ b/locations/watford.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Watford?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/west-london.html
+++ b/locations/west-london.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -118,7 +142,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in West London?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/locations/westminster.html
+++ b/locations/westminster.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -124,7 +148,7 @@
                 <div class="service-cta">
                     <h3>Need a Locksmith in Westminster?</h3>
                     <p>We're just a phone call away. Contact us for immediate service.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/navbar.html
+++ b/navbar.html
@@ -14,7 +14,7 @@
             </ul>
         </nav>
         <div class="header-phone">
-            <a href="tel:02039513549">02039513549</a>
+            <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a>
             <div class="header-social">
                 <a href="https://www.facebook.com/profile.php?id=61581353704416" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>
                 <a href="https://www.instagram.com/lockersmithuk/" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/services.html
+++ b/services.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/services/car-lockout.html
+++ b/services/car-lockout.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -159,7 +183,7 @@
                 <div class="service-cta">
                     <h3>Locked Out of Your Car?</h3>
                     <p>Our mobile locksmiths will come to you. Call now for rapid assistance.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/commercial-locksmith.html
+++ b/services/commercial-locksmith.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -155,7 +179,7 @@
                 <div class="service-cta">
                     <h3>Enhance Your Business Security</h3>
                     <p>Schedule a consultation with our commercial security experts today.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/emergency-locksmith.html
+++ b/services/emergency-locksmith.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -130,7 +154,7 @@
                     <p>Whenever you find yourself in a difficult situation that can only be solved efficiently with the help of a locksmith, call for assistance today. We are able to deal with the most difficult situations, with the resources necessary to help with any type of lockout.</p>
 
                     <h3>Benefits of Working with Locker Smith for 24-Hour Emergency Locksmith Service</h3>
-                    <p>If you are in the process of researching the market, looking for professional locksmith teams and 24-hour emergency locksmith services in London, keep our direct line close <a href="tel:02039513549">02039513549</a>. Our dedicated team offers any type of locksmith service you need, with the following advantages:</p>
+                    <p>If you are in the process of researching the market, looking for professional locksmith teams and 24-hour emergency locksmith services in London, keep our direct line close <a href="tel:02039513549" onclick="return gtag_report_conversion(this.href);">02039513549</a>. Our dedicated team offers any type of locksmith service you need, with the following advantages:</p>
                     <ul>
                         <li>Immediate assistance</li>
                         <li>Latest technologies</li>
@@ -158,7 +182,7 @@
                 <div class="service-cta">
                     <h3>Need Emergency Help?</h3>
                     <p>Don't wait. Call us now for immediate assistance.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/key-cutting.html
+++ b/services/key-cutting.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -150,7 +174,7 @@
                 <div class="service-cta">
                     <h3>Need a Key Cut?</h3>
                     <p>We cut keys while you wait. Call us to book or visit our workshop.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/lock-replacement.html
+++ b/services/lock-replacement.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -149,7 +173,7 @@
                 <div class="service-cta">
                     <h3>Want to Replace Your Locks?</h3>
                     <p>Contact us today for a free quote and security consultation.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/residential-locksmith.html
+++ b/services/residential-locksmith.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -152,7 +176,7 @@
                 <div class="service-cta">
                     <h3>Need to Secure Your Home?</h3>
                     <p>For a comprehensive home security solution, give us a call today.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/safe-opening.html
+++ b/services/safe-opening.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -150,7 +174,7 @@
                 <div class="service-cta">
                     <h3>Can't Open Your Safe?</h3>
                     <p>Our safe engineers are available to help. Call us for a confidential consultation.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/smart-lock-installation.html
+++ b/services/smart-lock-installation.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -150,7 +174,7 @@
                 <div class="service-cta">
                     <h3>Ready for a Smart Lock?</h3>
                     <p>Call us to schedule a smart lock installation or get expert advice.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>

--- a/services/upvc-door-repairs.html
+++ b/services/upvc-door-repairs.html
@@ -1,6 +1,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=AW-17608473030"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'AW-17608473030');
+    </script>
+    <!-- Event snippet for Contact conversion page In your html page, add the snippet and call gtag_report_conversion when someone clicks on the chosen link or button. -->
+    <script>
+        function gtag_report_conversion(url) {
+            var callback = function () {
+                if (typeof(url) != 'undefined') {
+                    window.location = url;
+                }
+            };
+            gtag('event', 'conversion', {
+                'send_to': 'AW-17608473030/PWGPCMDb56QbEMbzr8xB',
+                'event_callback': callback
+            });
+            return false;
+        }
+    </script>
+
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -150,7 +174,7 @@
                 <div class="service-cta">
                     <h3>Problems with a UPVC Door?</h3>
                     <p>Don't let a small problem become a big one. Call us for a free assessment.</p>
-                    <a href="tel:02039513549" class="cta-button">Call Now: 02039513549</a>
+                    <a href="tel:02039513549" class="cta-button" onclick="return gtag_report_conversion(this.href);">Call Now: 02039513549</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add the Google Ads global site tag and conversion snippet to every HTML page so the phone conversion can be tracked consistently
- wire all telephone links and shared UI templates to call `gtag_report_conversion` and update the Google Ads config with the provided conversion label

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1b0358dc832b8cf767b766c55f0b